### PR TITLE
Correción de links relativos

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
       <aside class="col-md">
 
         <header>
-          <h1 data-id="this-is-cs50x"><a href="/index.html">Esto es CS50x</a></h1>
+          <h1 data-id="this-is-cs50x"><a href="index.html">Esto es CS50x</a></h1>
 
           <p>OpenCourseWare</p>
 
@@ -115,35 +115,35 @@
             <li data-marker="*"><a href="new/index.html">Novedades de la edición 2021</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="/weeks/0/index.html">Semana 0</a> Scratch</li>
-            <li data-marker="*"><a href="/weeks/1/index.html">Semana 1</a> C</li>
-            <li data-marker="*"><a href="/weeks/2/index.html">Semana 2</a> Arrays</li>
-            <li data-marker="*"><a href="/weeks/3/index.html">Semana 3</a> Algoritmos</li>
-            <li data-marker="*"><a href="/weeks/4/index.html">Semana 4</a> Memoria</li>
-            <li data-marker="*"><a href="/weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
-            <li data-marker="*"><a href="/weeks/6/index.html">Semana 6</a> Python</li>
-            <li data-marker="*"><a href="/weeks/7/index.html">Semana 7</a> SQL</li>
-            <li data-marker="*"><a href="/weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
-            <li data-marker="*"><a href="/weeks/9/index.html">Semana 9</a> Flask</li>
-            <li data-marker="*"><a href="/weeks/10/index.html">Semana 10</a> Ética</li>
+            <li data-marker="*"><a href="weeks/0/index.html">Semana 0</a> Scratch</li>
+            <li data-marker="*"><a href="weeks/1/index.html">Semana 1</a> C</li>
+            <li data-marker="*"><a href="weeks/2/index.html">Semana 2</a> Arrays</li>
+            <li data-marker="*"><a href="weeks/3/index.html">Semana 3</a> Algoritmos</li>
+            <li data-marker="*"><a href="weeks/4/index.html">Semana 4</a> Memoria</li>
+            <li data-marker="*"><a href="weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
+            <li data-marker="*"><a href="weeks/6/index.html">Semana 6</a> Python</li>
+            <li data-marker="*"><a href="weeks/7/index.html">Semana 7</a> SQL</li>
+            <li data-marker="*"><a href="weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
+            <li data-marker="*"><a href="weeks/9/index.html">Semana 9</a> Flask</li>
+            <li data-marker="*"><a href="weeks/10/index.html">Semana 10</a> Ética</li>
           </ul>
           <ul>
-            <li data-marker="*" class="small"><a href="/weeks/security/index.html">Seguridad Informática</a></li>
-            <li data-marker="*" class="small"><a href="/weeks/ai/index.html">Inteligencia Artificial</a></li>
+            <li data-marker="*" class="small"><a href="weeks/security/index.html">Seguridad Informática</a></li>
+            <li data-marker="*" class="small"><a href="weeks/ai/index.html">Inteligencia Artificial</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="/project/index.html">Proyecto Final</a></li>
+            <li data-marker="*"><a href="project/index.html">Proyecto Final</a></li>
           </ul>
 
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="/honesty/index.html">Honestidad Académica</a></li>
-            <li data-marker="*"><a href="/certificate/index.html">Certificado de CS50</a></li>
-            <li data-marker="*"><a href="/faqs/index.html">Preguntas Frecuentes</a></li>
+            <li data-marker="*"><a href="honesty/index.html">Honestidad Académica</a></li>
+            <li data-marker="*"><a href="certificate/index.html">Certificado de CS50</a></li>
+            <li data-marker="*"><a href="faqs/index.html">Preguntas Frecuentes</a></li>
             <li data-marker="*"><a href="https://cs50.me/cs50x">Calificaciones</a></li>
-            <li data-marker="*"><a href="/staff/index.html">Staff</a></li>
-            <li data-marker="*"><a href="/syllabus/index.html">Temario</a></li>
+            <li data-marker="*"><a href="staff/index.html">Staff</a></li>
+            <li data-marker="*"><a href="syllabus/index.html">Temario</a></li>
           </ul>
 
           <hr>

--- a/notes/0/index.html
+++ b/notes/0/index.html
@@ -70,7 +70,7 @@
       <aside class="col-md">
 
         <header>
-          <h1 data-id="this-is-cs50x"><a href="/index.html">Esto es CS50x</a></h1>
+          <h1 data-id="this-is-cs50x"><a href="../../index.html">Esto es CS50x</a></h1>
 
           <p>OpenCourseWare</p>
 
@@ -110,40 +110,40 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="/gallery/index.html">Galería de Proyectos 2020</a> <span
+            <li data-marker="*"><a href="../../gallery/index.html">Galería de Proyectos 2020</a> <span
                 class="pl-1 text-white">🖼️ </span></li>
-            <li data-marker="*"><a href="/new/index.html">Novedades de la edición 2021</a></li>
+            <li data-marker="*"><a href="../../new/index.html">Novedades de la edición 2021</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="/weeks/0/index.html">Semana 0</a> Scratch</li>
-            <li data-marker="*"><a href="/weeks/1/index.html">Semana 1</a> C</li>
-            <li data-marker="*"><a href="/weeks/2/index.html">Semana 2</a> Arrays</li>
-            <li data-marker="*"><a href="/weeks/3/index.html">Semana 3</a> Algoritmos</li>
-            <li data-marker="*"><a href="/weeks/4/index.html">Semana 4</a> Memoria</li>
-            <li data-marker="*"><a href="/weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
-            <li data-marker="*"><a href="/weeks/6/index.html">Semana 6</a> Python</li>
-            <li data-marker="*"><a href="/weeks/7/index.html">Semana 7</a> SQL</li>
-            <li data-marker="*"><a href="/weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
-            <li data-marker="*"><a href="/weeks/9/index.html">Semana 9</a> Flask</li>
-            <li data-marker="*"><a href="/weeks/10/index.html">Semana 10</a> Ética</li>
+            <li data-marker="*"><a href="../../weeks/0/index.html">Semana 0</a> Scratch</li>
+            <li data-marker="*"><a href="../../weeks/1/index.html">Semana 1</a> C</li>
+            <li data-marker="*"><a href="../../weeks/2/index.html">Semana 2</a> Arrays</li>
+            <li data-marker="*"><a href="../../weeks/3/index.html">Semana 3</a> Algoritmos</li>
+            <li data-marker="*"><a href="../../weeks/4/index.html">Semana 4</a> Memoria</li>
+            <li data-marker="*"><a href="../../weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
+            <li data-marker="*"><a href="../../weeks/6/index.html">Semana 6</a> Python</li>
+            <li data-marker="*"><a href="../../weeks/7/index.html">Semana 7</a> SQL</li>
+            <li data-marker="*"><a href="../../weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
+            <li data-marker="*"><a href="../../weeks/9/index.html">Semana 9</a> Flask</li>
+            <li data-marker="*"><a href="../../weeks/10/index.html">Semana 10</a> Ética</li>
           </ul>
           <ul>
-            <li data-marker="*" class="small"><a href="weeks/security/index.html">Seguridad Informática</a></li>
-            <li data-marker="*" class="small"><a href="weeks/ai/index.html">Inteligencia Artificial</a></li>
+            <li data-marker="*" class="small"><a href="../../weeks/security/index.html">Seguridad Informática</a></li>
+            <li data-marker="*" class="small"><a href="../../weeks/ai/index.html">Inteligencia Artificial</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="project/index.html">Proyecto Final</a></li>
+            <li data-marker="*"><a href="../../project/index.html">Proyecto Final</a></li>
           </ul>
 
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="honesty/index.html">Honestidad Académica</a></li>
-            <li data-marker="*"><a href="certificate/index.html">Certificado de CS50</a></li>
+            <li data-marker="*"><a href="../../honesty/index.html">Honestidad Académica</a></li>
+            <li data-marker="*"><a href="../../certificate/index.html">Certificado de CS50</a></li>
             <li data-marker="*"><a href="faqs/index.html">Preguntas Frecuentes</a></li>
             <li data-marker="*"><a href="https://cs50.me/cs50x">Calificaciones</a></li>
-            <li data-marker="*"><a href="staff/index.html">Staff</a></li>
-            <li data-marker="*"><a href="syllabus/index.html">Temario</a></li>
+            <li data-marker="*"><a href="../../staff/index.html">Staff</a></li>
+            <li data-marker="*"><a href="../../syllabus/index.html">Temario</a></li>
           </ul>
 
           <hr>
@@ -196,7 +196,7 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="communities/index.html">Comunidades Oficiales CS50</a></li>
+            <li data-marker="*"><a href="../../communities/index.html">Comunidades Oficiales CS50</a></li>
             <li data-marker="*" class="small">(En inglés)</li>
             <li data-marker="*" class="small"><a href="https://discord.gg/cs50">Discord</a></li>
             <li data-marker="*" class="small"><a href="https://www.facebook.com/groups/cs50/">Facebook Group</a></li>
@@ -223,7 +223,7 @@
 
           <hr>
 
-          <p><a href="license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
+          <p><a href="../../license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
         </nav>
 
         <footer></footer>

--- a/psets/0/index.html
+++ b/psets/0/index.html
@@ -70,7 +70,7 @@
       <aside class="col-md">
 
         <header>
-          <h1 data-id="this-is-cs50x"><a href="/index.html">Esto es CS50x</a></h1>
+          <h1 data-id="this-is-cs50x"><a href="../../index.html">Esto es CS50x</a></h1>
 
           <p>OpenCourseWare</p>
 
@@ -110,40 +110,40 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="/gallery/index.html">Galería de Proyectos 2020</a> <span
+            <li data-marker="*"><a href="../../gallery/index.html">Galería de Proyectos 2020</a> <span
                 class="pl-1 text-white">🖼️ </span></li>
-            <li data-marker="*"><a href="/new/index.html">Novedades de la edición 2021</a></li>
+            <li data-marker="*"><a href="../../new/index.html">Novedades de la edición 2021</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="/weeks/0/index.html">Semana 0</a> Scratch</li>
-            <li data-marker="*"><a href="/weeks/1/index.html">Semana 1</a> C</li>
-            <li data-marker="*"><a href="/weeks/2/index.html">Semana 2</a> Arrays</li>
-            <li data-marker="*"><a href="/weeks/3/index.html">Semana 3</a> Algoritmos</li>
-            <li data-marker="*"><a href="/weeks/4/index.html">Semana 4</a> Memoria</li>
-            <li data-marker="*"><a href="/weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
-            <li data-marker="*"><a href="/weeks/6/index.html">Semana 6</a> Python</li>
-            <li data-marker="*"><a href="/weeks/7/index.html">Semana 7</a> SQL</li>
-            <li data-marker="*"><a href="/weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
-            <li data-marker="*"><a href="/weeks/9/index.html">Semana 9</a> Flask</li>
-            <li data-marker="*"><a href="/weeks/10/index.html">Semana 10</a> Ética</li>
+            <li data-marker="*"><a href="../../weeks/0/index.html">Semana 0</a> Scratch</li>
+            <li data-marker="*"><a href="../../weeks/1/index.html">Semana 1</a> C</li>
+            <li data-marker="*"><a href="../../weeks/2/index.html">Semana 2</a> Arrays</li>
+            <li data-marker="*"><a href="../../weeks/3/index.html">Semana 3</a> Algoritmos</li>
+            <li data-marker="*"><a href="../../weeks/4/index.html">Semana 4</a> Memoria</li>
+            <li data-marker="*"><a href="../../weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
+            <li data-marker="*"><a href="../../weeks/6/index.html">Semana 6</a> Python</li>
+            <li data-marker="*"><a href="../../weeks/7/index.html">Semana 7</a> SQL</li>
+            <li data-marker="*"><a href="../../weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
+            <li data-marker="*"><a href="../../weeks/9/index.html">Semana 9</a> Flask</li>
+            <li data-marker="*"><a href="../../weeks/10/index.html">Semana 10</a> Ética</li>
           </ul>
           <ul>
-            <li data-marker="*" class="small"><a href="weeks/security/index.html">Seguridad Informática</a></li>
-            <li data-marker="*" class="small"><a href="weeks/ai/index.html">Inteligencia Artificial</a></li>
+            <li data-marker="*" class="small"><a href="../../weeks/security/index.html">Seguridad Informática</a></li>
+            <li data-marker="*" class="small"><a href="../../weeks/ai/index.html">Inteligencia Artificial</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="project/index.html">Proyecto Final</a></li>
+            <li data-marker="*"><a href="../../project/index.html">Proyecto Final</a></li>
           </ul>
 
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="honesty/index.html">Honestidad Académica</a></li>
-            <li data-marker="*"><a href="certificate/index.html">Certificado de CS50</a></li>
-            <li data-marker="*"><a href="faqs/index.html">Preguntas Frecuentes</a></li>
+            <li data-marker="*"><a href="../../honesty/index.html">Honestidad Académica</a></li>
+            <li data-marker="*"><a href="../../certificate/index.html">Certificado de CS50</a></li>
+            <li data-marker="*"><a href="../../faqs/index.html">Preguntas Frecuentes</a></li>
             <li data-marker="*"><a href="https://cs50.me/cs50x">Calificaciones</a></li>
-            <li data-marker="*"><a href="staff/index.html">Staff</a></li>
-            <li data-marker="*"><a href="syllabus/index.html">Temario</a></li>
+            <li data-marker="*"><a href="../../staff/index.html">Staff</a></li>
+            <li data-marker="*"><a href="../../syllabus/index.html">Temario</a></li>
           </ul>
 
           <hr>
@@ -196,7 +196,7 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="communities/index.html">Comunidades Oficiales CS50</a></li>
+            <li data-marker="*"><a href="../../communities/index.html">Comunidades Oficiales CS50</a></li>
             <li data-marker="*" class="small">(En inglés)</li>
             <li data-marker="*" class="small"><a href="https://discord.gg/cs50">Discord</a></li>
             <li data-marker="*" class="small"><a href="https://www.facebook.com/groups/cs50/">Facebook Group</a></li>
@@ -223,7 +223,7 @@
 
           <hr>
 
-          <p><a href="license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
+          <p><a href="../../license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
         </nav>
 
         <footer></footer>

--- a/psets/0/scratch/index.html
+++ b/psets/0/scratch/index.html
@@ -71,7 +71,7 @@
       <aside class="col-md">
 
         <header>
-          <h1 data-id="this-is-cs50x"><a href="/index.html">Esto es CS50x</a></h1>
+          <h1 data-id="this-is-cs50x"><a href="../../../index.html">Esto es CS50x</a></h1>
 
           <p>OpenCourseWare</p>
 
@@ -111,40 +111,40 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="/gallery/index.html">Galería de Proyectos 2020</a> <span
+            <li data-marker="*"><a href="../../../gallery/index.html">Galería de Proyectos 2020</a> <span
                 class="pl-1 text-white">🖼️ </span></li>
-            <li data-marker="*"><a href="/new/index.html">Novedades de la edición 2021</a></li>
+            <li data-marker="*"><a href="../../../new/index.html">Novedades de la edición 2021</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="/weeks/0/index.html">Semana 0</a> Scratch</li>
-            <li data-marker="*"><a href="/weeks/1/index.html">Semana 1</a> C</li>
-            <li data-marker="*"><a href="/weeks/2/index.html">Semana 2</a> Arrays</li>
-            <li data-marker="*"><a href="/weeks/3/index.html">Semana 3</a> Algoritmos</li>
-            <li data-marker="*"><a href="/weeks/4/index.html">Semana 4</a> Memoria</li>
-            <li data-marker="*"><a href="/weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
-            <li data-marker="*"><a href="/weeks/6/index.html">Semana 6</a> Python</li>
-            <li data-marker="*"><a href="/weeks/7/index.html">Semana 7</a> SQL</li>
-            <li data-marker="*"><a href="/weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
-            <li data-marker="*"><a href="/weeks/9/index.html">Semana 9</a> Flask</li>
-            <li data-marker="*"><a href="/weeks/10/index.html">Semana 10</a> Ética</li>
+            <li data-marker="*"><a href="../../../weeks/0/index.html">Semana 0</a> Scratch</li>
+            <li data-marker="*"><a href="../../../weeks/1/index.html">Semana 1</a> C</li>
+            <li data-marker="*"><a href="../../../weeks/2/index.html">Semana 2</a> Arrays</li>
+            <li data-marker="*"><a href="../../../weeks/3/index.html">Semana 3</a> Algoritmos</li>
+            <li data-marker="*"><a href="../../../weeks/4/index.html">Semana 4</a> Memoria</li>
+            <li data-marker="*"><a href="../../../weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
+            <li data-marker="*"><a href="../../../weeks/6/index.html">Semana 6</a> Python</li>
+            <li data-marker="*"><a href="../../../weeks/7/index.html">Semana 7</a> SQL</li>
+            <li data-marker="*"><a href="../../../weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
+            <li data-marker="*"><a href="../../../weeks/9/index.html">Semana 9</a> Flask</li>
+            <li data-marker="*"><a href="../../../weeks/10/index.html">Semana 10</a> Ética</li>
           </ul>
           <ul>
-            <li data-marker="*" class="small"><a href="weeks/security/index.html">Seguridad Informática</a></li>
-            <li data-marker="*" class="small"><a href="weeks/ai/index.html">Inteligencia Artificial</a></li>
+            <li data-marker="*" class="small"><a href="../../../weeks/security/index.html">Seguridad Informática</a></li>
+            <li data-marker="*" class="small"><a href="../../../weeks/ai/index.html">Inteligencia Artificial</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="project/index.html">Proyecto Final</a></li>
+            <li data-marker="*"><a href="../../../project/index.html">Proyecto Final</a></li>
           </ul>
 
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="honesty/index.html">Honestidad Académica</a></li>
-            <li data-marker="*"><a href="certificate/index.html">Certificado de CS50</a></li>
-            <li data-marker="*"><a href="faqs/index.html">Preguntas Frecuentes</a></li>
+            <li data-marker="*"><a href="../../../honesty/index.html">Honestidad Académica</a></li>
+            <li data-marker="*"><a href="../../../certificate/index.html">Certificado de CS50</a></li>
+            <li data-marker="*"><a href="../../../faqs/index.html">Preguntas Frecuentes</a></li>
             <li data-marker="*"><a href="https://cs50.me/cs50x">Calificaciones</a></li>
-            <li data-marker="*"><a href="staff/index.html">Staff</a></li>
-            <li data-marker="*"><a href="syllabus/index.html">Temario</a></li>
+            <li data-marker="*"><a href="../../../staff/index.html">Staff</a></li>
+            <li data-marker="*"><a href="../../../syllabus/index.html">Temario</a></li>
           </ul>
 
           <hr>
@@ -197,7 +197,7 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="communities/index.html">Comunidades Oficiales CS50</a></li>
+            <li data-marker="*"><a href="../../../communities/index.html">Comunidades Oficiales CS50</a></li>
             <li data-marker="*" class="small">(En inglés)</li>
             <li data-marker="*" class="small"><a href="https://discord.gg/cs50">Discord</a></li>
             <li data-marker="*" class="small"><a href="https://www.facebook.com/groups/cs50/">Facebook Group</a></li>
@@ -224,7 +224,7 @@
 
           <hr>
 
-          <p><a href="license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
+          <p><a href="../../../license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
         </nav>
 
         <footer></footer>

--- a/weeks/0/index.html
+++ b/weeks/0/index.html
@@ -70,7 +70,7 @@
       <aside class="col-md">
 
         <header>
-          <h1 data-id="this-is-cs50x"><a href="/index.html">Esto es CS50x</a></h1>
+          <h1 data-id="this-is-cs50x"><a href="../../index.html">Esto es CS50x</a></h1>
 
           <p>OpenCourseWare</p>
 
@@ -110,40 +110,40 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="gallery/index.html">Galería de Proyectos 2020</a> <span
+            <li data-marker="*"><a href="../../gallery/index.html">Galería de Proyectos 2020</a> <span
                 class="pl-1 text-white">🖼️ </span></li>
-            <li data-marker="*"><a href="new/index.html">Novedades de la edición 2021</a></li>
+            <li data-marker="*"><a href="../../new/index.html">Novedades de la edición 2021</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="weeks/0/index.html">Semana 0</a> Scratch</li>
-            <li data-marker="*"><a href="weeks/1/index.html">Semana 1</a> C</li>
-            <li data-marker="*"><a href="weeks/2/index.html">Semana 2</a> Arrays</li>
-            <li data-marker="*"><a href="weeks/3/index.html">Semana 3</a> Algoritmos</li>
-            <li data-marker="*"><a href="weeks/4/index.html">Semana 4</a> Memoria</li>
-            <li data-marker="*"><a href="weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
-            <li data-marker="*"><a href="weeks/6/index.html">Semana 6</a> Python</li>
-            <li data-marker="*"><a href="weeks/7/index.html">Semana 7</a> SQL</li>
-            <li data-marker="*"><a href="weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
-            <li data-marker="*"><a href="weeks/9/index.html">Semana 9</a> Flask</li>
-            <li data-marker="*"><a href="weeks/10/index.html">Semana 10</a> Ética</li>
+            <li data-marker="*"><a href="../../weeks/0/index.html">Semana 0</a> Scratch</li>
+            <li data-marker="*"><a href="../../weeks/1/index.html">Semana 1</a> C</li>
+            <li data-marker="*"><a href="../../weeks/2/index.html">Semana 2</a> Arrays</li>
+            <li data-marker="*"><a href="../../weeks/3/index.html">Semana 3</a> Algoritmos</li>
+            <li data-marker="*"><a href="../../weeks/4/index.html">Semana 4</a> Memoria</li>
+            <li data-marker="*"><a href="../../weeks/5/index.html">Semana 5</a> Estructuras de Datos</li>
+            <li data-marker="*"><a href="../../weeks/6/index.html">Semana 6</a> Python</li>
+            <li data-marker="*"><a href="../../weeks/7/index.html">Semana 7</a> SQL</li>
+            <li data-marker="*"><a href="../../weeks/8/index.html">Semana 8</a> HTML, CSS, JavaScript</li>
+            <li data-marker="*"><a href="../../weeks/9/index.html">Semana 9</a> Flask</li>
+            <li data-marker="*"><a href="../../weeks/10/index.html">Semana 10</a> Ética</li>
           </ul>
           <ul>
-            <li data-marker="*" class="small"><a href="weeks/security/index.html">Seguridad Informática</a></li>
-            <li data-marker="*" class="small"><a href="weeks/ai/index.html">Inteligencia Artificial</a></li>
+            <li data-marker="*" class="small"><a href="../../weeks/security/index.html">Seguridad Informática</a></li>
+            <li data-marker="*" class="small"><a href="../../weeks/ai/index.html">Inteligencia Artificial</a></li>
           </ul>
           <ul>
-            <li data-marker="*"><a href="project/index.html">Proyecto Final</a></li>
+            <li data-marker="*"><a href="../../project/index.html">Proyecto Final</a></li>
           </ul>
 
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="honesty/index.html">Honestidad Académica</a></li>
-            <li data-marker="*"><a href="certificate/index.html">Certificado de CS50</a></li>
-            <li data-marker="*"><a href="faqs/index.html">Preguntas Frecuentes</a></li>
+            <li data-marker="*"><a href="../../honesty/index.html">Honestidad Académica</a></li>
+            <li data-marker="*"><a href="../../certificate/index.html">Certificado de CS50</a></li>
+            <li data-marker="*"><a href="../../faqs/index.html">Preguntas Frecuentes</a></li>
             <li data-marker="*"><a href="https://cs50.me/cs50x">Calificaciones</a></li>
-            <li data-marker="*"><a href="staff/index.html">Staff</a></li>
-            <li data-marker="*"><a href="syllabus/index.html">Temario</a></li>
+            <li data-marker="*"><a href="../../staff/index.html">Staff</a></li>
+            <li data-marker="*"><a href="../../syllabus/index.html">Temario</a></li>
           </ul>
 
           <hr>
@@ -196,7 +196,7 @@
           <hr>
 
           <ul>
-            <li data-marker="*"><a href="communities/index.html">Comunidades Oficiales CS50</a></li>
+            <li data-marker="*"><a href="../../communities/index.html">Comunidades Oficiales CS50</a></li>
             <li data-marker="*" class="small">(En inglés)</li>
             <li data-marker="*" class="small"><a href="https://discord.gg/cs50">Discord</a></li>
             <li data-marker="*" class="small"><a href="https://www.facebook.com/groups/cs50/">Facebook Group</a></li>
@@ -223,7 +223,7 @@
 
           <hr>
 
-          <p><a href="license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
+          <p><a href="../../license/index.html" class="small"><i class="fab fa-creative-commons mr-1"></i>Licencia</a></p>
         </nav>
 
         <footer></footer>


### PR DESCRIPTION
Los links relativos se construyen con el path hasta el index usando secuencias de `..` para ir al directorio superior mientras sea necesario. Esta es la misma forma en la que se resuelvan los paths de los recursos como CSS.